### PR TITLE
Add the range to tap handlers.

### DIFF
--- a/ActiveLabelDemo/ViewController.swift
+++ b/ActiveLabelDemo/ViewController.swift
@@ -39,9 +39,9 @@ class ViewController: UIViewController {
             label.URLColor = UIColor(red: 85.0/255, green: 238.0/255, blue: 151.0/255, alpha: 1)
             label.URLSelectedColor = UIColor(red: 82.0/255, green: 190.0/255, blue: 41.0/255, alpha: 1)
 
-            label.handleMentionTap { self.alert("Mention", message: $0) }
-            label.handleHashtagTap { self.alert("Hashtag", message: $0) }
-            label.handleURLTap { self.alert("URL", message: $0.absoluteString) }
+            label.handleMentionTap { self.alert("Mention", message: $0.0) }
+            label.handleHashtagTap { self.alert("Hashtag", message: $0.0) }
+            label.handleURLTap { self.alert("URL", message: $0.0.absoluteString) }
 
             //Custom types
 
@@ -61,9 +61,9 @@ class ViewController: UIViewController {
                 return atts
             }
 
-            label.handleCustomTap(for: customType) { self.alert("Custom type", message: $0) }
-            label.handleCustomTap(for: customType2) { self.alert("Custom type", message: $0) }
-            label.handleCustomTap(for: customType3) { self.alert("Custom type", message: $0) }
+            label.handleCustomTap(for: customType) { self.alert("Custom type", message: $0.0) }
+            label.handleCustomTap(for: customType2) { self.alert("Custom type", message: $0.0) }
+            label.handleCustomTap(for: customType3) { self.alert("Custom type", message: $0.0) }
         }
 
         label.frame = CGRect(x: 20, y: 40, width: view.frame.width - 40, height: 300)


### PR DESCRIPTION
With complex custom types regexes it wasn't apparent which element was tapped if the label text contains duplicates.

Example "This sample text is a great sample". regex: sample.

By passing the range to the tap handler the caller can calculate which "sample" was tapped on. I added it to all the type handlers for consistency.