### PR TITLE
Add a new active type - custom range, whcih lets you specify a specific range you want to use instead of a regex

### DIFF
--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -97,7 +97,7 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
             mentionTapHandler = nil
         case .url:
             urlTapHandler = nil
-        case .custom:
+        case .custom, .customRange:
             customTapHandlers[type] = nil
         }
     }
@@ -282,18 +282,16 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
             return
         }
 
-        let mutAttrString = addLineBreak(attributedText)
+        let mutAttrString = NSMutableAttributedString(attributedString: attributedText)
 
         if parseText {
             clearActiveElements()
-            let newString = parseTextAndExtractActiveElements(mutAttrString)
-            mutAttrString.mutableString.setString(newString)
+            _ = parseTextAndExtractActiveElements(mutAttrString)
         }
 
         addLinkAttribute(mutAttrString)
         textStorage.setAttributedString(mutAttrString)
         _customizing = true
-        text = mutAttrString.string
         _customizing = false
         setNeedsDisplay()
     }
@@ -329,7 +327,7 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
             case .mention: attributes[NSAttributedStringKey.foregroundColor] = mentionColor
             case .hashtag: attributes[NSAttributedStringKey.foregroundColor] = hashtagColor
             case .url: attributes[NSAttributedStringKey.foregroundColor] = URLColor
-            case .custom: attributes[NSAttributedStringKey.foregroundColor] = customColor[type] ?? defaultCustomColor
+            case .custom, .customRange: attributes[NSAttributedStringKey.foregroundColor] = customColor[type] ?? defaultCustomColor
             }
             
             if let highlightFont = hightlightFont {
@@ -409,7 +407,7 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
             case .mention: selectedColor = mentionSelectedColor ?? mentionColor
             case .hashtag: selectedColor = hashtagSelectedColor ?? hashtagColor
             case .url: selectedColor = URLSelectedColor ?? URLColor
-            case .custom:
+            case .custom, .customRange:
                 let possibleSelectedColor = customSelectedColor[selectedElement.type] ?? customColor[selectedElement.type]
                 selectedColor = possibleSelectedColor ?? defaultCustomColor
             }
@@ -420,7 +418,7 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
             case .mention: unselectedColor = mentionColor
             case .hashtag: unselectedColor = hashtagColor
             case .url: unselectedColor = URLColor
-            case .custom: unselectedColor = customColor[selectedElement.type] ?? defaultCustomColor
+            case .custom, .customRange: unselectedColor = customColor[selectedElement.type] ?? defaultCustomColor
             }
             attributes[NSAttributedStringKey.foregroundColor] = unselectedColor
         }

--- a/ActiveLabel/ActiveType.swift
+++ b/ActiveLabel/ActiveType.swift
@@ -19,7 +19,7 @@ enum ActiveElement {
         case .mention: return mention(text)
         case .hashtag: return hashtag(text)
         case .url: return url(original: text, trimmed: text)
-        case .custom: return custom(text)
+        case .custom, .customRange: return custom(text)
         }
     }
 }
@@ -29,6 +29,7 @@ public enum ActiveType {
     case hashtag
     case url
     case custom(pattern: String)
+    case customRange(NSRange)
 
     var pattern: String {
         switch self {
@@ -36,6 +37,7 @@ public enum ActiveType {
         case .hashtag: return RegexParser.hashtagPattern
         case .url: return RegexParser.urlPattern
         case .custom(let regex): return regex
+        case .customRange(_): return ""
         }
     }
 }
@@ -47,6 +49,7 @@ extension ActiveType: Hashable, Equatable {
         case .hashtag: return -2
         case .url: return -3
         case .custom(let regex): return regex.hashValue
+        case .customRange(let range): return range.hashValue
         }
     }
 }
@@ -57,6 +60,7 @@ public func ==(lhs: ActiveType, rhs: ActiveType) -> Bool {
     case (.hashtag, .hashtag): return true
     case (.url, .url): return true
     case (.custom(let pattern1), .custom(let pattern2)): return pattern1 == pattern2
+    case (.customRange(let range1), .customRange(let range2)): return range1 == range2
     default: return false
     }
 }

--- a/ActiveLabelTests/ActiveTypeTests.swift
+++ b/ActiveLabelTests/ActiveTypeTests.swift
@@ -255,7 +255,7 @@ class ActiveTypeTests: XCTestCase {
     }
 
     func testRemoveHandleMention() {
-        label.handleMentionTap({_ in })
+        label.handleMentionTap({_, _ in })
         XCTAssertNotNil(label.handleMentionTap)
         
         label.removeHandle(for: .mention)
@@ -263,7 +263,7 @@ class ActiveTypeTests: XCTestCase {
     }
     
     func testRemoveHandleHashtag() {
-        label.handleHashtagTap({_ in })
+        label.handleHashtagTap({_, _ in })
         XCTAssertNotNil(label.handleHashtagTap)
         
         label.removeHandle(for: .hashtag)
@@ -271,7 +271,7 @@ class ActiveTypeTests: XCTestCase {
     }
     
     func testRemoveHandleURL() {
-        label.handleURLTap({_ in })
+        label.handleURLTap({_, _ in })
         XCTAssertNotNil(label.handleURLTap)
         
         label.removeHandle(for: .url)
@@ -282,8 +282,8 @@ class ActiveTypeTests: XCTestCase {
         let newType1 = ActiveType.custom(pattern: "\\sare1\\b")
         let newType2 = ActiveType.custom(pattern: "\\sare2\\b")
         
-        label.handleCustomTap(for: newType1, handler: {_ in })
-        label.handleCustomTap(for: newType2, handler: {_ in })
+        label.handleCustomTap(for: newType1, handler: {_, _ in })
+        label.handleCustomTap(for: newType2, handler: {_, _ in })
         XCTAssertEqual(label.customTapHandlers.count, 2)
         
         label.removeHandle(for: newType1)
@@ -397,13 +397,14 @@ class ActiveTypeTests: XCTestCase {
         XCTAssertEqual(currentElementType, customEmptyType)
     }
 
-    func testStringTrimming() {
-        let text = "Tweet with long url: https://twitter.com/twicket_app/status/649678392372121601 and short url: https://hello.co"
-        label.urlMaximumLength = 30
-        label.text = text
-
-        XCTAssertNotEqual(text.characters.count, label.text!.characters.count)
-    }
+    // urlMaxiumumLength no longer works because we never want to change the string length now that we've enabled attributed strings
+//    func testStringTrimming() {
+//        let text = "Tweet with long url: https://twitter.com/twicket_app/status/649678392372121601 and short url: https://hello.co"
+//        label.urlMaximumLength = 30
+//        label.text = text
+//
+//        XCTAssertNotEqual(text.characters.count, label.text!.characters.count)
+//    }
 
     func testStringTrimmingURLShorterThanLimit() {
         let text = "Tweet with short url: https://hello.co"
@@ -413,24 +414,24 @@ class ActiveTypeTests: XCTestCase {
         XCTAssertEqual(text, label.text!)
     }
 
-    func testStringTrimmingURLLongerThanLimit() {
-        let trimLimit = 30
-        let url = "https://twitter.com/twicket_app/status/649678392372121601"
-        let trimmedURL = url.trim(to: trimLimit)
-        let text = "Tweet with long url: \(url)"
-        label.urlMaximumLength = trimLimit
-        label.text = text
-
-
-        XCTAssertNotEqual(text.characters.count, label.text!.characters.count)
-
-        switch activeElements.first! {
-        case .url(let original, let trimmed):
-            XCTAssertEqual(original, url)
-            XCTAssertEqual(trimmed, trimmedURL)
-        default:
-            XCTAssert(false)
-        }
-
-    }
+    // urlMaxiumumLength no longer works because we never want to change the string length now that we've enabled attributed strings
+//    func testStringTrimmingURLLongerThanLimit() {
+//        let trimLimit = 30
+//        let url = "https://twitter.com/twicket_app/status/649678392372121601"
+//        let trimmedURL = url.trim(to: trimLimit)
+//        let text = "Tweet with long url: \(url)"
+//        label.urlMaximumLength = trimLimit
+//        label.text = text
+//
+//
+//        XCTAssertNotEqual(text.characters.count, label.text!.characters.count)
+//
+//        switch activeElements.first! {
+//        case .url(let original, let trimmed):
+//            XCTAssertEqual(original, url)
+//            XCTAssertEqual(trimmed, trimmedURL)
+//        default:
+//            XCTAssert(false)
+//        }
+//    }
 }


### PR DESCRIPTION
Allows attributed strings in active label. This breaks url shortening, but that's ok because we don't currently use that feature.
It breaks URL shortening because active label can no longer change the string passed to it. This would break the attributes on the string since they're index based.