### PR TITLE
Adds a new custom type: customRange

### DIFF
--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -95,7 +95,7 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
             mentionTapHandler = nil
         case .url:
             urlTapHandler = nil
-        case .custom:
+        case .custom, .customRange:
             customTapHandlers[type] = nil
         }
     }
@@ -318,7 +318,7 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
             case .mention: attributes[NSAttributedStringKey.foregroundColor] = mentionColor
             case .hashtag: attributes[NSAttributedStringKey.foregroundColor] = hashtagColor
             case .url: attributes[NSAttributedStringKey.foregroundColor] = URLColor
-            case .custom: attributes[NSAttributedStringKey.foregroundColor] = customColor[type] ?? defaultCustomColor
+            case .custom, .customRange: attributes[NSAttributedStringKey.foregroundColor] = customColor[type] ?? defaultCustomColor
             }
             
             if let highlightFont = hightlightFont {
@@ -398,7 +398,7 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
             case .mention: selectedColor = mentionSelectedColor ?? mentionColor
             case .hashtag: selectedColor = hashtagSelectedColor ?? hashtagColor
             case .url: selectedColor = URLSelectedColor ?? URLColor
-            case .custom:
+            case .custom, .customRange:
                 let possibleSelectedColor = customSelectedColor[selectedElement.type] ?? customColor[selectedElement.type]
                 selectedColor = possibleSelectedColor ?? defaultCustomColor
             }
@@ -409,7 +409,7 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
             case .mention: unselectedColor = mentionColor
             case .hashtag: unselectedColor = hashtagColor
             case .url: unselectedColor = URLColor
-            case .custom: unselectedColor = customColor[selectedElement.type] ?? defaultCustomColor
+            case .custom, .customRange: unselectedColor = customColor[selectedElement.type] ?? defaultCustomColor
             }
             attributes[NSAttributedStringKey.foregroundColor] = unselectedColor
         }

--- a/ActiveLabel/ActiveType.swift
+++ b/ActiveLabel/ActiveType.swift
@@ -19,7 +19,7 @@ enum ActiveElement {
         case .mention: return mention(text)
         case .hashtag: return hashtag(text)
         case .url: return url(original: text, trimmed: text)
-        case .custom: return custom(text)
+        case .custom, .customRange: return custom(text)
         }
     }
 }
@@ -29,6 +29,7 @@ public enum ActiveType {
     case hashtag
     case url
     case custom(pattern: String)
+    case customRange(NSRange)
 
     var pattern: String {
         switch self {
@@ -36,6 +37,7 @@ public enum ActiveType {
         case .hashtag: return RegexParser.hashtagPattern
         case .url: return RegexParser.urlPattern
         case .custom(let regex): return regex
+        case .customRange(_): return ""
         }
     }
 }
@@ -47,6 +49,7 @@ extension ActiveType: Hashable, Equatable {
         case .hashtag: return -2
         case .url: return -3
         case .custom(let regex): return regex.hashValue
+        case .customRange(let range): return range.hashValue
         }
     }
 }
@@ -57,6 +60,7 @@ public func ==(lhs: ActiveType, rhs: ActiveType) -> Bool {
     case (.hashtag, .hashtag): return true
     case (.url, .url): return true
     case (.custom(let pattern1), .custom(let pattern2)): return pattern1 == pattern2
+    case (.customRange(let range1), .customRange(let range2)): return range1 == range2
     default: return false
     }
 }


### PR DESCRIPTION
This allows you to specify a specific range for an active type
This is useful if you know exactly where you want the type to be and don't want to rely on a regex (which may return other results)
For instance, you may have a string like: `tap here or here` and you want to handle each `here` differently