### PR TITLE
Re-add missing linebreak modes to text storage

### DIFF
--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -282,7 +282,7 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
             return
         }
 
-        let mutAttrString = NSMutableAttributedString(attributedString: attributedText)
+        let mutAttrString = NSMutableAttributedString(attributedString: addLineBreak(attributedText))
 
         // If the string changes in length, then we need to reset the string (because the attributes have changed indexes)
         // Otherwise, we can use the attributed string as is


### PR DESCRIPTION
This was causing the intrinsicContentSize to never include multilines.