### PR TITLE
Use look-behind assertion for characters preceding url

### DIFF
--- a/ActiveLabel/RegexParser.swift
+++ b/ActiveLabel/RegexParser.swift
@@ -12,7 +12,7 @@ struct RegexParser {
 
     static let hashtagPattern = "(?:^|\\s|$)#[\\p{L}0-9_]*"
     static let mentionPattern = "(?:^|\\s|$|[.])@[\\p{L}0-9_]*"
-    static let urlPattern = "(^|[\\s.:;?\\-\\]<\\(])" +
+    static let urlPattern = "(?<=^|[\\s.:;?\\-\\]<\\(])" +
         "((https?://|www\\.|pic\\.)[-\\w;/?:@&=+$\\|\\_.!~*\\|'()\\[\\]%#,☺]+[\\w/#](\\(\\))?)" +
     "(?=$|[\\s',\\|\\(\\).:;?\\-\\[\\]>\\)])"
 

--- a/ActiveLabelTests/ActiveTypeTests.swift
+++ b/ActiveLabelTests/ActiveTypeTests.swift
@@ -186,6 +186,16 @@ class ActiveTypeTests: XCTestCase {
 
         label.text = "google.com"
         XCTAssertEqual(activeElements.count, 0)
+        
+        label.text = "parens (pic.twitter.com/YUGdEbUx)"
+        XCTAssertEqual(activeElements.count, 1)
+        XCTAssertEqual(currentElementString, "pic.twitter.com/YUGdEbUx")
+        XCTAssertEqual(currentElementType, ActiveType.url)
+        
+        label.text = "parens (https://www.google.com/hello)"
+        XCTAssertEqual(activeElements.count, 1)
+        XCTAssertEqual(currentElementString, "https://www.google.com/hello")
+        XCTAssertEqual(currentElementType, ActiveType.url)
     }
 
     func testCustomType() {


### PR DESCRIPTION
By using a look behind assertion for characters preceding the url, they are not included in the captured range. This was required for urls that are surrounded by parens.